### PR TITLE
修正身份驗證提供者支持方法並重命名資料傳輸物件

### DIFF
--- a/src/main/java/com/crater/accounting/bean/service/userDetailsService/UserDetailsServiceDto.java
+++ b/src/main/java/com/crater/accounting/bean/service/userDetailsService/UserDetailsServiceDto.java
@@ -1,4 +1,4 @@
-package com.crater.accounting.bean.service;
+package com.crater.accounting.bean.service.userDetailsService;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/com/crater/accounting/config/ApplicationConfig.java
+++ b/src/main/java/com/crater/accounting/config/ApplicationConfig.java
@@ -42,7 +42,6 @@ public class ApplicationConfig {
         var providerManager = new ProviderManager(Collections.singletonList(authenticationProvider));
         return http
                 .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("swagger-ui/**", "/swagger-ui.html", "open-api/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 ).httpBasic(withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
@@ -51,7 +50,8 @@ public class ApplicationConfig {
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers("/js/**", "/css/**", "/accountController/account");
+        return (web) -> web.ignoring().requestMatchers("/js/**", "/css/**", "/accountController/account",
+                "swagger-ui/**", "/swagger-ui.html", "open-api/**", "/v3/api-docs/**");
     }
 
     @Bean

--- a/src/main/java/com/crater/accounting/security/AuthenticationProviderImpl.java
+++ b/src/main/java/com/crater/accounting/security/AuthenticationProviderImpl.java
@@ -55,7 +55,7 @@ public class AuthenticationProviderImpl implements AuthenticationProvider {
 
     @Override
     public boolean supports(Class<?> authentication) {
-        return true;
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
     }
 
     @Autowired

--- a/src/main/java/com/crater/accounting/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/com/crater/accounting/service/impl/UserDetailsServiceImpl.java
@@ -1,7 +1,7 @@
 package com.crater.accounting.service.impl;
 
 import com.crater.accounting.bean.database.UserDataPojo;
-import com.crater.accounting.bean.service.UserDetailsServiceDto;
+import com.crater.accounting.bean.service.userDetailsService.UserDetailsServiceDto;
 import com.crater.accounting.dao.UserDataDao;
 import com.crater.accounting.dao.UserRedisDao;
 import com.crater.accounting.exception.DbException;


### PR DESCRIPTION
修正了`supports`方法以正確檢查身份驗證類型。重命名並重新組織了`UserDetailsServiceDto`類路徑，並修改相應的引用。更新了安全配置以允許對Swagger相關路徑的訪問。